### PR TITLE
Fix issue #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DocBlockr (Visual Studio Code)
 
+[![Build Status](https://travis-ci.org/jeremyvii/vs-docblockr.svg?branch=master)](https://travis-ci.org/jeremyvii/vs-docblockr)
+
 A Visual Studio Code port of the Atom package [Docblockr](https://github.com/nikhilkalige/docblockr). 
 
 [Extension page](https://marketplace.visualstudio.com/items?itemName=jeremyljackson.vs-docblock)

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -622,7 +622,7 @@ export class Lexer {
   protected tag(): boolean {
     let matches;
     // Expression define valid tag types
-    const regex = /^([_\w$](?:[_\-:\w$]*[_\w$])?)/;
+    const regex = /^([_\w<>\[\]$](?:[_\-:\w<>\[\]$]*[_\w<>\[\]$])?)/;
     // Try to capture matches
     if (matches = regex.exec(this.input)) {
       // Set tag name

--- a/test/languages/typescript.test.ts
+++ b/test/languages/typescript.test.ts
@@ -68,6 +68,14 @@ suite('TypeScript', function () {
       assert.equal(token.return.type, 'boolean');
     });
 
+    test('should parse function with array return type', function () {
+      let token = parser.tokenize('function foo(): Array<number> {');
+      assert.equal(token.name, 'foo');
+      assert.equal(token.type, 'function');
+      assert.equal(token.return.present, true);
+      assert.equal(token.return.type, 'Array<number>');
+    });
+
     test('should parse class', function () {
       let token = parser.tokenize('class Bar {');
       assert.equal(token.name, 'Bar');


### PR DESCRIPTION
Fixes issue #4 by allowing `<>` in lexer. This is to account for typescript variable types such as, `Array<number>`.