### PR TITLE
Fix Issue 33

### DIFF
--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -49,7 +49,7 @@ export class TypeScript extends Parser {
         // Prevent lexer errors by stripping out semi-colons
         code = code.replace(';', '');
         // Create an expression for finding any function parameters
-        const paramsExp = /\(([\w$:\s,]+)\)/;
+        const paramsExp = /\(([\w$:\s,\[\]]+)\)/;
         // If no results are found based on expression, return code as is
         if (!paramsExp.test(code)) return code;
         // Grab parameter section of function

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -181,7 +181,7 @@ export class TypeScript extends Parser {
             Expression that separates function argument from argument type. This
             separation between the two is delimited by a colon (`:`)
             */
-            const argTypeRegex = new RegExp(/([a-zA-Z_$][\w$]*):([a-zA-Z_$][\w$]*)/);
+            const argTypeRegex = new RegExp(/([a-zA-Z_$][\w$]*):([a-zA-Z_$][\w$\[\]]*)/);
             // Check if object is an attribute
             if (lexed[i].type === 'attribute') {
               // By default set name to whatever the lexer returned

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -181,7 +181,7 @@ export class TypeScript extends Parser {
             Expression that separates function argument from argument type. This
             separation between the two is delimited by a colon (`:`)
             */
-            const argTypeRegex = new RegExp(/([a-zA-Z_$][0-9a-zA-Z_$]*):([a-zA-Z_$][0-9a-zA-Z_$]*)/);
+            const argTypeRegex = new RegExp(/([a-zA-Z_$][\w$]*):([a-zA-Z_$][\w$]*)/);
             // Check if object is an attribute
             if (lexed[i].type === 'attribute') {
               // By default set name to whatever the lexer returned

--- a/test/languages/typescript.test.ts
+++ b/test/languages/typescript.test.ts
@@ -58,6 +58,17 @@ suite('TypeScript', function () {
       assert.equal(token.return.present, true);
     });
 
+    test('should parse arguments with array type', function () {
+      let token = parser.tokenize('function foo(arg: number[]) {');
+      assert.equal(token.name, 'foo');
+      assert.equal(token.type, 'function');
+      assert.equal(token.params.length, 1);
+      assert.equal(token.params[0].name, 'arg');
+      assert.equal(token.params[0].val, '');
+      assert.equal(token.params[0].type, 'number[]');
+      assert.equal(token.return.present, true);
+    });
+
     test('should parse function with return type', function () {
       let token = parser.tokenize('function foo(): boolean {');
       assert.equal(token.name, 'foo');


### PR DESCRIPTION
Fix issue #33 by allowing arguments with typed arrays. Some expressions have been simplified with `\w` word selector.