### PR TITLE
Register Vue.js language with TypeScript parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Currently three languages have been implemented:
 * PHP
 * SCSS
 * TypeScript
+* Vue.js
 
 More languages to come in the future.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "onLanguage:php",
     "onLanguage:typescript",
     "onLanguage:java",
-    "onLanguage:scss"
+    "onLanguage:scss",
+    "onLanguage:vue"
   ],
   "main": "./out/src/extension",
   "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,7 @@ export function activate(context: ExtensionContext) {
     php: PHP,
     scss: Scss,
     typescript: TypeScript,
+    vue: TypeScript,
   };
   // Register each language
   for (const language in langList) {


### PR DESCRIPTION
Add support for [Vue.js](https://vuejs.org/) by registering the `vue` language ID with the TypeScript parser. This will close #45.