### PR TITLE
Parse arguments with or without types

### DIFF
--- a/src/languages/php.ts
+++ b/src/languages/php.ts
@@ -223,6 +223,8 @@ export class PHP extends Parser {
 
       if (lastParam) {
         lastParam.name = token.value;
+
+        this.expectParameterType = false;
       }
     }
   }

--- a/test/languages/php.test.ts
+++ b/test/languages/php.test.ts
@@ -66,6 +66,20 @@ suite('PHP', () => {
       assert.strictEqual(token.return.type, 'boolean');
     });
 
+    test('should parse function arguments with or without types', () => {
+      const token = parser.getSymbols('function foo(int $fizz, $buzz): boolean {');
+
+      assert.strictEqual(token.name, 'foo');
+      assert.strictEqual(token.type, SymbolKind.Function);
+      assert.strictEqual(token.params.length, 2);
+
+      assert.strictEqual(token.params[0].name, `$fizz`);
+      assert.strictEqual(token.params[0].type, 'int');
+      assert.strictEqual(token.params[1].name, `$buzz`);
+
+      assert.strictEqual(token.return.type, 'boolean');
+    });
+
     test('should parameters with types', () => {
       const token = parser.getSymbols('function foo(int $bar) {');
 


### PR DESCRIPTION
Fix #60 by resetting the `Parser.expectParameterType` flag to `false` after adding the name.