### PR TITLE
Fix multi-line indention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,22 @@ Don't commit to the master branch. When fixing issues or adding features, please
  - Write comments, describe why you did what you did
  - Submit a pull request with your bug fix or new feature
 
+## Getting started
+
+You can view the documentation for vscode extension development
+[here](https://code.visualstudio.com/api).
+
+[nvm](https://github.com/nvm-sh/nvm) is used to keep the version of `npm`
+consistent. Run the following to install the appropriate node modules.
+
+``` shell
+nvm i; npm i
+```
+
+Run `Test Extension` to run unit tests. Run `Launch Extension` to launch an
+instance of the extension from your local repository.
+
 ## Coding Style
 
-You can use [TSlint configuration](https://github.com/jeremyvii/vs-docblockr/blob/master/.eslintrc.js)
+You can use reference the [TSlint configuration](https://github.com/jeremyvii/vs-docblockr/blob/master/tslint.json)
 to reference full code style.

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -212,12 +212,17 @@ export abstract class Parser {
         return document.lineAt(selection.anchor).text;
       }
 
-      const start = selection.anchor.line;
-      const end = selection.active.line;
+      const { start, end } = selection;
 
-      console.log();
+      const lines = [] as number[];
 
-      return '';
+      for (let i = end.line; i >= start.line; i--) {
+        lines.push(i);
+      }
+
+      const text = lines.reverse().map((line) => document.lineAt(line).text).join('\n');
+
+      return text;
     }
 
   /**
@@ -327,8 +332,7 @@ export abstract class Parser {
    */
   public renderFromSelection(selection: Selection): SnippetString {
     // Retrieve the code from the selection
-    const code = window.activeTextEditor.document.getText(selection);
-    console.log(code);
+    const code = this.getTextFromSelection(selection);
 
     // Generate symbols from the code string
     const symbols = this.getSymbols(code);
@@ -338,7 +342,7 @@ export abstract class Parser {
 
     // Concatenate the docblock with the code to replace the selected code with
     // the snippet
-    return new SnippetString(block).appendText('\n').appendText(`${code}`);
+    return new SnippetString(block);
   }
 
   /**

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,5 @@
 import { Token, tokenizer } from 'acorn';
-import { Selection, SymbolKind, TextEditor, window, workspace, WorkspaceConfiguration } from 'vscode';
+import { Selection, SymbolKind, TextEditor, window, workspace, WorkspaceConfiguration, SnippetString } from 'vscode';
 
 import { Grammar } from './grammar';
 import { IOptions, Settings } from './settings';
@@ -306,13 +306,13 @@ export abstract class Parser {
   /**
    * Renders a docblock string from the provided selection
    *
-   * @param   {Selection}  selection  The current selection in the editor
+   * @param   {Selection}     selection  The current selection in the editor
    *
-   * @return  {string}                The rendered docblock
+   * @return  {SnippetString}            The rendered docblock in a snippet string
    */
-  public renderFromSelection(selection: Selection): string {
+  public renderFromSelection(selection: Selection): SnippetString {
     // Retrieve the code from the selection
-    const code = window.activeTextEditor.document.getText(selection);
+    const code = window.activeTextEditor.document.getText(selection).trim();
 
     // Generate symbols from the code string
     const symbols = this.getSymbols(code);
@@ -320,9 +320,9 @@ export abstract class Parser {
     // Render a docblock from the symbols
     const block = this.renderBlock(symbols);
 
-    // Concantant the docblock with the code to replace the selected code with
+    // Concatenate the docblock with the code to replace the selected code with
     // the snippet
-    return `${block}\n${code}`;
+    return new SnippetString(block).appendText(`\n${code}`);
   }
 
   /**

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -206,33 +206,6 @@ export abstract class Parser {
   }
 
   /**
-   * Retrieve text from a selection
-   *
-   * @param   {Selection}  selection  A section in the editor
-   *
-   * @return  {string}                The code within the selection
-   */
-  public getTextFromSelection(selection: Selection): string {
-    const { document } = window.activeTextEditor;
-
-    if (selection.isSingleLine) {
-      return document.lineAt(selection.anchor).text;
-    }
-
-    const { start, end } = selection;
-
-    const lines = [] as number[];
-
-    for (let i = end.line; i >= start.line; i--) {
-      lines.push(i);
-    }
-
-    const text = lines.reverse().map((line) => document.lineAt(line).text).join('\n');
-
-    return text;
-  }
-
-  /**
    * Retrieve a list of Acorn tokens from a code snippet.
    *
    * @param   {string}  code  The code snippet to build tokens from.
@@ -277,8 +250,10 @@ export abstract class Parser {
       // Attempt to get token information needed for render doc string
       const symbols = this.getSymbols(nextLineTrimmed);
       return this.renderBlock(symbols);
-    } catch (e) {
-      window.showErrorMessage(e.message);
+    } catch (error) {
+      if (error instanceof Error) {
+        window.showErrorMessage(error.message);
+      }
 
       // If no valid token was created, create an empty doc block string
       return this.renderEmptyBlock();
@@ -346,7 +321,8 @@ export abstract class Parser {
    */
   public renderFromSelection(selection: Selection): SnippetString {
     // Retrieve the code from the selection
-    const code = this.getTextFromSelection(selection);
+    const { document } = window.activeTextEditor;
+    const code = document.getText(selection);
 
     // Generate symbols from the code string
     const symbols = this.getSymbols(code);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,5 @@
 import { Token, tokenizer } from 'acorn';
-import { Selection, SymbolKind, TextEditor, window, workspace, WorkspaceConfiguration, SnippetString } from 'vscode';
+import { Selection, SnippetString, SymbolKind, TextEditor, window, workspace, WorkspaceConfiguration } from 'vscode';
 
 import { Grammar } from './grammar';
 import { IOptions, Settings } from './settings';
@@ -205,6 +205,21 @@ export abstract class Parser {
     return symbols;
   }
 
+    public getTextFromSelection(selection: Selection): string {
+      const { document } = window.activeTextEditor;
+
+      if (selection.isSingleLine) {
+        return document.lineAt(selection.anchor).text;
+      }
+
+      const start = selection.anchor.line;
+      const end = selection.active.line;
+
+      console.log();
+
+      return '';
+    }
+
   /**
    * Retrieve a list of Acorn tokens from a code snippet.
    *
@@ -312,7 +327,8 @@ export abstract class Parser {
    */
   public renderFromSelection(selection: Selection): SnippetString {
     // Retrieve the code from the selection
-    const code = window.activeTextEditor.document.getText(selection).trim();
+    const code = window.activeTextEditor.document.getText(selection);
+    console.log(code);
 
     // Generate symbols from the code string
     const symbols = this.getSymbols(code);
@@ -322,7 +338,7 @@ export abstract class Parser {
 
     // Concatenate the docblock with the code to replace the selected code with
     // the snippet
-    return new SnippetString(block).appendText(`\n${code}`);
+    return new SnippetString(block).appendText('\n').appendText(`${code}`);
   }
 
   /**

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -1,4 +1,5 @@
 import {
+  commands,
   CompletionItem,
   CompletionItemKind,
   CompletionItemProvider,
@@ -107,7 +108,7 @@ export class Snippets implements CompletionItemProvider {
    *
    * @param  {TextEditor}  editor  The currently active texteditor
    */
-  public static provideRenderFromSelectionSnippet(editor: TextEditor) {
+  public static async provideRenderFromSelectionSnippet(editor: TextEditor) {
     // Retrieve the current selection from the editor
     const { selection } = editor;
 
@@ -119,6 +120,8 @@ export class Snippets implements CompletionItemProvider {
 
     // Render a docblock from the selection
     const block = parser.renderFromSelection(selection);
+
+    await commands.executeCommand('editor.action.insertLineBefore');
 
     editor.insertSnippet(block);
   }

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -120,7 +120,7 @@ export class Snippets implements CompletionItemProvider {
     // Render a docblock from the selection
     const block = parser.renderFromSelection(selection);
 
-    editor.insertSnippet(new SnippetString(block));
+    editor.insertSnippet(block);
   }
 
   /**

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -161,7 +161,7 @@ export class Snippets implements CompletionItemProvider {
    * @return  {Selection}             The reserved selection
    */
   protected static reverseMultiLinedSelection(selection: Selection): Selection {
-    if (selection.isSingleLine && !selection.isReversed) {
+    if (selection.isSingleLine || selection.isReversed) {
       return selection;
     }
 

--- a/test/TestEditor.ts
+++ b/test/TestEditor.ts
@@ -12,6 +12,8 @@ export default class TestEditor {
       language,
     }).then((textDocument) => {
       window.showTextDocument(textDocument).then((textEditor) => {
+        textEditor.options.tabSize = 2;
+
         callback.call(this, textEditor, textDocument);
       }, (error) => {
         // tslint:disable-next-line: no-console

--- a/test/TestEditor.ts
+++ b/test/TestEditor.ts
@@ -1,4 +1,4 @@
-import { TextDocument, TextEditor, window, workspace } from 'vscode';
+import { Selection, TextDocument, TextEditor, TextEditorEdit, window, workspace } from 'vscode';
 
 /**
  * Provides helper methods for testing the editor
@@ -34,5 +34,20 @@ export default class TestEditor {
     return new Promise((resolve) => {
       setTimeout(resolve, milliseconds);
     });
+  }
+
+  /**
+   * Empties the provided text document
+   *
+   * @param   {TextEditorEdit}  builder   The text editor edit instance
+   * @param   {TextDocument}    document  The text document to clear
+   */
+  public static clearDocument(builder: TextEditorEdit, document: TextDocument) {
+    const selection = new Selection(
+      document.positionAt(0),
+      document.positionAt(document.getText().length),
+    );
+
+    builder.delete(selection);
   }
 }

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,5 +1,7 @@
 import * as assert from 'assert';
+
 import { TypeScript } from '../src/languages/typescript';
+
 import config from './defaultConfiguration';
 
 // Use the JavaScript parser for the sake of setup
@@ -16,7 +18,7 @@ suite('Parser', () => {
 
       const expected = [
         '/**',
-        ' *',
+        ' * ${1:[description]}',
         ' */',
       ].join('\n');
 

--- a/test/snippets.test.ts
+++ b/test/snippets.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { commands, Selection, SnippetString, TextDocument, TextEditor, workspace } from 'vscode';
+import { commands, Selection, SnippetString, TextDocument, TextEditor } from 'vscode';
 
 import { Snippets } from '../src/snippets';
 
@@ -104,7 +104,7 @@ suite('Snippets', () => {
     test('should preserve indention', async () => {
       await editor.insertSnippet(new SnippetString('  function foo(bar) {}'));
 
-      const selection = new Selection(document.positionAt(0), document.positionAt(document.getText().length - 1));
+      const selection = new Selection(document.positionAt(2), document.positionAt(document.getText().length - 1));
 
       editor.selection = selection;
 
@@ -123,6 +123,35 @@ suite('Snippets', () => {
         '   * @return  {[type]}       [return description]',
         '   */',
         '  function foo(bar) {}',
+      ].join('\n');
+
+      assert.strictEqual(actual, expected);
+    });
+
+    test('should preserve indention in multiline function signatures', async () => {
+      await editor.insertSnippet(new SnippetString('  function foo(\n    bar\n  ) {}'));
+
+      const selection = new Selection(document.positionAt(2), document.positionAt(document.getText().length));
+
+      editor.selection = selection;
+
+      await commands.executeCommand('vs-docblockr.renderFromSelection');
+
+      await TestEditor.delay(2000);
+
+      const actual = document.getText();
+
+      const expected = [
+        '  /**',
+        '   * [foo description]',
+        '   *',
+        '   * @param   {[type]}  bar  [bar description]',
+        '   *',
+        '   * @return  {[type]}       [return description]',
+        '   */',
+        '  function foo(',
+        '    bar',
+        '  ) {}',
       ].join('\n');
 
       assert.strictEqual(actual, expected);

--- a/test/snippets.test.ts
+++ b/test/snippets.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { commands, Selection, SnippetString, TextDocument, TextEditor } from 'vscode';
+import { commands, Selection, SnippetString, TextDocument, TextEditor, workspace } from 'vscode';
 
 import { Snippets } from '../src/snippets';
 
@@ -66,23 +66,23 @@ suite('Snippets', () => {
     let document: TextDocument;
 
     suiteSetup((done) => {
-      TestEditor.loadEditor('typescript', async (textEditor, textDocument) => {
+      TestEditor.loadEditor('typescript', (textEditor, textDocument) => {
         editor = textEditor;
         document = textDocument;
-
-        await editor.insertSnippet(new SnippetString('function foo(bar) {}'));
-
-        const selection = new Selection(document.positionAt(0), document.positionAt(document.getText().length - 1));
-
-        editor.selection = selection;
-
-        await commands.executeCommand('vs-docblockr.renderFromSelection');
 
         done();
       });
     });
 
     test('should parse selected snippet', async () => {
+      await editor.insertSnippet(new SnippetString('function foo(bar) {}'));
+
+      const selection = new Selection(document.positionAt(0), document.positionAt(document.getText().length - 1));
+
+      editor.selection = selection;
+
+      await commands.executeCommand('vs-docblockr.renderFromSelection');
+
       await TestEditor.delay(2000);
 
       const actual = document.getText();
@@ -99,6 +99,43 @@ suite('Snippets', () => {
       ].join('\n');
 
       assert.strictEqual(actual, expected);
+    });
+
+    test('should preserve indention', async () => {
+      await editor.insertSnippet(new SnippetString('  function foo(bar) {}'));
+
+      const selection = new Selection(document.positionAt(0), document.positionAt(document.getText().length - 1));
+
+      editor.selection = selection;
+
+      await commands.executeCommand('vs-docblockr.renderFromSelection');
+
+      await TestEditor.delay(2000);
+
+      const actual = document.getText();
+
+      const expected = [
+        '  /**',
+        '   * [foo description]',
+        '   *',
+        '   * @param   {[type]}  bar  [bar description]',
+        '   *',
+        '   * @return  {[type]}       [return description]',
+        '   */',
+        '  function foo(bar) {}',
+      ].join('\n');
+
+      assert.strictEqual(actual, expected);
+    });
+
+    teardown((done) => {
+      editor.edit((builder) => {
+        const selection = new Selection(document.positionAt(0), document.positionAt(document.getText().length));
+
+        builder.delete(selection);
+
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
This PR renders a docblock without replacing the selected code. This will close #69. 

Additionally, this PR adjusts empty blocks, returned from `Parser.rendeEmptyBlock()`, as snippet strings, focusing in the middle of the docblock block for better UX. A vscode error message is rendered and an empty block is generated if Acorn throws an error.