### PR TITLE
Skip null types

### DIFF
--- a/src/languages/php.ts
+++ b/src/languages/php.ts
@@ -73,7 +73,9 @@ export class PHP extends Parser {
 
     const classExpression = /^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/;
 
-    return notReserved && (isType || classExpression.test(type));
+    const notNull = !/(null|NULL)/.test(type);
+
+    return notReserved && notNull && (isType || classExpression.test(type));
   }
 
   /**

--- a/test/languages/php.test.ts
+++ b/test/languages/php.test.ts
@@ -81,6 +81,30 @@ suite('PHP', () => {
       assert.strictEqual(token.return.type, 'boolean');
     });
 
+    test('should parse function arguments with default values', () => {
+      const token = parser.getSymbols('function foo($bar = 4): boolean {');
+
+      assert.strictEqual(token.name, 'foo');
+      assert.strictEqual(token.type, SymbolKind.Function);
+      assert.strictEqual(token.params.length, 1);
+
+      assert.strictEqual(token.params[0].name, `$bar`);
+
+      assert.strictEqual(token.return.type, 'boolean');
+    });
+
+    test('should parse function arguments with null as a default value', () => {
+      const token = parser.getSymbols('function foo($bar = NULL): boolean {');
+
+      assert.strictEqual(token.name, 'foo');
+      assert.strictEqual(token.type, SymbolKind.Function);
+      assert.strictEqual(token.params.length, 1);
+
+      assert.strictEqual(token.params[0].name, `$bar`);
+
+      assert.strictEqual(token.return.type, 'boolean');
+    });
+
     test('should parameters with types', () => {
       const token = parser.getSymbols('function foo(int $bar) {');
 


### PR DESCRIPTION
Closes #77 

Skip token types when they match `null` or `NULL`.